### PR TITLE
requirements: Add scipy.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scipy>=1.4.0
 python_osc>=1.7.0
 numpy>=1.15.4
 ipython>=7.2.0


### PR DESCRIPTION
Missing scipy dependency prevents startup of the SC server. I'm adding a reference in requirements.txt to scipy at version at least 1.4.0.